### PR TITLE
Enforcing the C++98 standard

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2,7 +2,7 @@
 YICES_DIR=/home/jburnim/yices-1.0.11
 
 CC=$(CXX)
-CFLAGS = -I. -I$(YICES_DIR)/include -Wall -O2
+CFLAGS = -I. -I$(YICES_DIR)/include -Wall -O2 -std=gnu++98
 CXXFLAGS = $(CFLAGS)
 LDFLAGS = -L$(YICES_DIR)/lib
 LOADLIBES = -lyices


### PR DESCRIPTION
g++ -I. -I/home/lmagoncalo/Desktop/yices-1.0.40/include -Wall -O2   -c -o base/basic_types.o base/basic_types.cc
base/basic_types.cc:96:1: error: narrowing conversion of ‘18446744073709551615’ from ‘long unsigned int’ to ‘crest::value_t {aka long long int}’ inside { } [-Wnarrowing]
 };
 ^
base/basic_types.cc:96:1: error: narrowing conversion of ‘18446744073709551615’ from ‘long long unsigned int’ to ‘crest::value_t {aka long long int}’ inside { } [-Wnarrowing]
<builtin>: recipe for target 'base/basic_types.o' failed
make: *** [base/basic_types.o] Error 1


For the successful compilation of the source code it is needed to enforce the C++98 standard in gcc. This can be mabe by adding the -std=c++98 flag to the make file.